### PR TITLE
Recreate .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE=pacific
+PG_USER=andrew
+PG_PASS=

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Helping people find things to do with their time.
 npm install
 ```
 2. Setup Postgres database to match settings in `/database/index.js`.
-3. Rename `.env.example` to `.env` and fill in the enironment variables.
+3. Copy `.env.example`, rename the copy to `.env`, and fill in the environment variables.
 4. Build scripts:
 ```
 npm run build


### PR DESCRIPTION
The `.env.example` file was accidentally removed from the repo, so this PR creates a new example and updates the README.