### PR TITLE
Update search when user is logged out

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -31,9 +31,10 @@ const App = () => {
 
 
 
-  const searchEvents = () => {
+  const searchEvents = (e) => {
     axios.get('/api/searchEvents/title', { params: { search: search }})
       .then((response) => {
+        console.log('searching');
         setSearchEvent(response.data)
       })
       .catch((error) => {
@@ -64,9 +65,9 @@ const App = () => {
       </Flex>
         <div className='homePageBackground'>
           <div className='searchBarFlex'>
-            <form>
+            <form onSubmit={(e) => {searchEvents(e)}}>
               <input type='text' className='homePageSearch' placeholder='What do you want to do?' onChange={(e) => {setSearch(e.target.value)}}/>
-              <button className='homePageSearchButton' color='#EC7C71' onClick={() => { searchEvents(search) }}>
+              <button className='homePageSearchButton' color='#EC7C71' type="submit">
                 Go!
               </button>
             </form>
@@ -99,10 +100,12 @@ const App = () => {
        </Flex>
          <div className='homePageBackground'>
            <div className='searchBarFlex'>
-             <input type='text' className='homePageSearch' placeholder='What do you want to do?' onChange={(e) => {setSearch(e.target.value)}}/>
-             <button className='homePageSearchButton' color='#EC7C71' onClick={searchEvents(search)}>
-               Go!
-             </button>
+            <form onSubmit={(e) => {searchEvents(e)}}>
+              <input type='text' className='homePageSearch' placeholder='What do you want to do?' onChange={(e) => {setSearch(e.target.value)}}/>
+              <button className='homePageSearchButton' color='#EC7C71' type="submit">
+                Go!
+              </button>
+             </form>
            </div>
          </div>
        <HomePage

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -31,7 +31,8 @@ const App = () => {
 
 
 
-  const searchEvents = () => {
+  const searchEvents = (e) => {
+    e.preventDefault();
     axios.get('/api/searchEvents/title', { params: { search: search }})
       .then((response) => {
         setSearchEvent(response.data)
@@ -64,7 +65,7 @@ const App = () => {
       </Flex>
         <div className='homePageBackground'>
           <div className='searchBarFlex'>
-            <form onSubmit={(e) => {searchEvents(e)}}>
+            <form onSubmit={searchEvents}>
               <input type='text' className='homePageSearch' placeholder='What do you want to do?' onChange={(e) => {setSearch(e.target.value)}}/>
               <button className='homePageSearchButton' color='#EC7C71' type="submit">
                 Go!
@@ -99,7 +100,7 @@ const App = () => {
        </Flex>
          <div className='homePageBackground'>
            <div className='searchBarFlex'>
-            <form onSubmit={(e) => {searchEvents(e)}}>
+            <form onSubmit={searchEvents}>
               <input type='text' className='homePageSearch' placeholder='What do you want to do?' onChange={(e) => {setSearch(e.target.value)}}/>
               <button className='homePageSearchButton' color='#EC7C71' type="submit">
                 Go!

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -31,10 +31,9 @@ const App = () => {
 
 
 
-  const searchEvents = (e) => {
+  const searchEvents = () => {
     axios.get('/api/searchEvents/title', { params: { search: search }})
       .then((response) => {
-        console.log('searching');
         setSearchEvent(response.data)
       })
       .catch((error) => {

--- a/server/models/events.js
+++ b/server/models/events.js
@@ -37,11 +37,11 @@ const searchEventsByTitle = (searchTerm, limit = 10, page = 0) => {
   const query = `
     select *
     from events
-    where title ilike '${searchTerm}%'
-    limit ${limit}
-    offset ${offset};
+    where lower(title) like lower($1)
+    limit $2
+    offset $3;
   `
-  return db.pool.query(query);
+  return db.pool.query(query, [`%${searchTerm}%`, limit, offset]);
 }
 
 const getUsersForEvent = (event_id) => {


### PR DESCRIPTION
- Didn't realize that there was a copy of the rendered page for when the user is logged out, so fixed the search form there too.
- Update search db query to match searchText in middle or end of string (previously it only matched an event if the search term was at the beginning of the event name)

I can make a PR later so that we just conditionally render the navbar menu items, rather than having two copies of the entire homepage code.