### PR TITLE
Update events, friends, and interests to use email as id

### DIFF
--- a/client/src/components/eventDetail.js
+++ b/client/src/components/eventDetail.js
@@ -20,25 +20,15 @@ import { MdAddBox, MdOutlineGroupAdd } from "react-icons/md";
 import moment from "moment";
 import { Link, useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
+import { auth } from './firebase';
+import { useAuthState } from 'react-firebase-hooks/auth';
 
 const EventDetail = ({ userId }) => {
+  const [user, loading, error] = useAuthState(auth);
   const params = useParams();
   const navigate = useNavigate();
   const [event, setEvent] = useState([]);
   const address = `${event.address_line_1} ${event.address_state} ${event.address_zip}`;
-  const currentUser_id = 1;
-
-  const theme = extendTheme({
-    colors: {
-      brand: {
-        100: "#2E2F30", //black {header}
-        200: "#8DD8E0", //blue {border color}
-        300: "#E3444B", //red  {buttons}
-        400: "#EC7C71", //orange {button border}
-        500: "#FBFAFA", //white {subheaders, text}
-      },
-    },
-  });
 
   useEffect(() => {
     if (params.eventId) {
@@ -54,7 +44,9 @@ const EventDetail = ({ userId }) => {
 
   const ReserveEvent = (e) => {
     e.preventDefault();
-    axios.post('/api/events/users', { user_id: currentUser_id, event_id: params.eventId });
+    if (user) {
+      axios.post('/api/events/users', { user_id: user.email, event_id: params.eventId });
+    }
   };
 
   return (

--- a/client/src/components/events/events.js
+++ b/client/src/components/events/events.js
@@ -4,21 +4,30 @@ import { Header } from '../header';
 import EventList from './eventList';
 import axios from 'axios';
 import {HamburgerIcon, ChatIcon, MinusIcon} from '@chakra-ui/icons';
+import { auth } from '../firebase';
+import { useAuthState } from 'react-firebase-hooks/auth';
 
 const Events = () => {
-
+  const [user, loading, error] = useAuthState(auth);
   let [events, setEvents] = useState([]);
   let [listStyle, setListStyle] = useState('block');
-  //dynamically set used id based on login, set to 1 right now
-  let [user_id, setUserId] = useState(1);
+  let [user_id, setUserId] = useState();
 
   useEffect(() => {
+    console.log('Passed in user_id: ', user_id);
+
+    if (!user_id && user) {
+      console.log('No user_id passed in, defaulting to logged in user: ', user.email);
+      setUserId(user.email);
+    }
+
     axios.get(`/api/events/user/${user_id}`)
     .then((response) => {
       setEvents(response.data);
     })
     .catch((err) => {console.log(err)});
-  },[])
+
+  },[user, user_id])
 
   return (
   <Box>

--- a/client/src/components/friends.jsx
+++ b/client/src/components/friends.jsx
@@ -6,23 +6,29 @@ import axios from 'axios';
 import { Header } from './header';
 import Friend from './friends/friend.jsx';
 import { useLocation } from 'react-router-dom';
+import { auth } from './firebase';
+import { useAuthState } from 'react-firebase-hooks/auth';
 
 function Friends() {
-  const [id, setUserId] = useState(1);
+  const [user, loading, error] = useAuthState(auth);
   const [friends, setFriends] = useState([]);
   const [filteredFriends, setFilteredFriends] = useState([]);
   const [event_id, setEventId] = useState(null);
   const [searchText, setSearchText] = useState('');
   const { state } = useLocation();
 
+  // fetch the user's friends
   useEffect(() => {
-    axios.get('/api/friends', { params: { id } })
-      .then((res) => {
-        setFriends(res.data);
-        setFilteredFriends(res.data);
-      });
-  }, [id]);
+    if (user) {
+      axios.get('/api/friends', { params: { id: user.email } })
+        .then((res) => {
+          setFriends(res.data);
+          setFilteredFriends(res.data);
+        });
+      }
+  }, [user]);
 
+  // search for friends
   useEffect(() => {
     let filteredFriends = friends.filter(friend => {
       const friendName = friend.full_name.toLowerCase();
@@ -35,7 +41,7 @@ function Friends() {
     if (state !== null) {
       setEventId(state.event_id)
     }
-  },[state])
+  }, [state])
 
   const handleChange = (e) => { setSearchText(e.target.value); };
 
@@ -51,7 +57,7 @@ function Friends() {
           {filteredFriends.length ? filteredFriends.map((friend) => (
             <Friend
               key={friend.id}
-              user_id={id}
+              user_id={user.email}
               friend={friend}
               event_id={event_id}
             />

--- a/client/src/components/friends/friend.jsx
+++ b/client/src/components/friends/friend.jsx
@@ -4,9 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { auth } from '../firebase';
 import { useAuthState } from 'react-firebase-hooks/auth';
-
 import pepe from '../../../public/images/PepeProfile.jpeg';
-
 
 function Friend({ user_id, friend, event_id }) {
   const navigate = useNavigate();

--- a/client/src/components/friends/friend.jsx
+++ b/client/src/components/friends/friend.jsx
@@ -35,7 +35,7 @@ function Friend({ user_id, friend, event_id }) {
   *******************************/
   const handleFriendClick = (e) => {
     const request = e.target.value;
-    const body = { user_id, friend_id: parseInt(friend.id, 10) };
+    const body = { user_id, friend_id: friend.id };
     if (request === 'add') {
       axios.post('/api/friends', body);
     } else if (request === 'remove') {
@@ -51,7 +51,7 @@ function Friend({ user_id, friend, event_id }) {
 
   const handleInvite = (e) => {
     const request = e.target.value;
-    const body = { event_id, user_id: parseInt(friend.id, 10), };
+    const body = { event_id, user_id: friend.id };
     if (request === 'invite') {
       axios.post('/api/events/users', body);
     } else if (request === 'uninvite') {

--- a/client/src/components/interests.js
+++ b/client/src/components/interests.js
@@ -33,7 +33,7 @@ const Interests = () => {
     <Header />
     <Box p={4} m={4} border='1px' borderRadius='10px' borderColor='#8F8F8F'>
       <Heading fontSize='5vh'>Interests</Heading>
-      <Preferences userId={1} />
+      <Preferences userId={user.email} />
     </Box>
   </Box>
   )

--- a/client/src/components/register.jsx
+++ b/client/src/components/register.jsx
@@ -27,18 +27,6 @@ export const Register = () => {
     axios.post('/api/users/add', body)
   };
 
-  const theme = extendTheme({
-    colors: {
-      brand: {
-        100: "#2E2F30",  //black {header}
-        200: "#8DD8E0",  //blue {border color}
-        300: "#E3444B",  //red  {buttons}
-        400: "#EC7C71",  //orange {button border}
-        500: "#FBFAFA",  //white {subheaders, text}
-      },
-    },
-  })
-
   useEffect(() => {
     const navigateToSurvey = () => navigate('/interests');
     if (error) return <img src="https://i0.wp.com/learn.onemonth.com/wp-content/uploads/2017/08/1-10.png?fit=845%2C503&ssl=1" alt="Error" />;

--- a/client/src/components/register.jsx
+++ b/client/src/components/register.jsx
@@ -20,6 +20,7 @@ export const Register = () => {
     registerWithEmailAndPassword(name, email, password);
 
     const body = {
+      id: email,
       email,
       full_name: name,
     }
@@ -36,7 +37,6 @@ export const Register = () => {
 
 
   return (
-    <ChakraProvider theme={theme}>
       <Box
         backgroundImage="url('./images/RaccoonParty.jpeg')"
         backgroundPosition="center"
@@ -122,6 +122,5 @@ export const Register = () => {
         </Box>
       </Flex>
     </Box>
-    </ChakraProvider >
   );
 };

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { ChakraProvider } from '@chakra-ui/react';
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { render } from 'react-dom';
-import { getAuth, onAuthStateChanged } from "firebase/auth";
 
 import App from './components/App.jsx';
 import Friends from './components/friends.jsx';
@@ -14,16 +13,6 @@ import { Login } from './components/login.jsx';
 import EventDetail from './components/eventDetail';
 
 import theme from './theme.js';
-
-
-const auth = getAuth();
-const user = auth.currentUser;
-
-if (user) {
-  const uid = user.uid;
-  const displayName = user.displayName;
-  const email = user.email;
-}
 
 render(
   <BrowserRouter>

--- a/database/schema-friends.sql
+++ b/database/schema-friends.sql
@@ -3,19 +3,9 @@ drop table if exists relationships cascade;
 
 create table relationships (
   id           bigserial not null primary key,
-  from_user_id bigserial not null,
-  to_user_id   bigserial not null
+  from_user_id varchar(50) not null,
+  to_user_id   varchar(50) not null
 );
-
--- Populate relationships
-insert into relationships (from_user_id, to_user_id) values (1, 2);
-insert into relationships (from_user_id, to_user_id) values (2, 1);
-
-insert into relationships (from_user_id, to_user_id) values (1, 4);
-insert into relationships (from_user_id, to_user_id) values (4, 1);
-
-insert into relationships (from_user_id, to_user_id) values (1, 6);
-insert into relationships (from_user_id, to_user_id) values (6, 2);
 
 alter table relationships add constraint from_user_id_fkey foreign key (from_user_id) references users(id);
 alter table relationships add constraint to_user_id_fkey foreign key (to_user_id) references users(id);

--- a/database/schema-user-preferences.sql
+++ b/database/schema-user-preferences.sql
@@ -26,8 +26,8 @@ create table preferences (
 );
 
 create table users_preferences (
-  user_id  bigserial not null,
-  preferences_id  bigserial not null,
+  user_id        varchar(50) not null,
+  preferences_id bigserial not null,
   foreign key (user_id) references users(id),
   foreign key (preferences_id) references preferences(id)
 );
@@ -69,9 +69,9 @@ values
 insert into users_preferences
   (user_id, preferences_id)
 values
-  (4, 1),
-  (4, 9),
-  (4, 16);
+  ('fernanda.rodrigues.cdc@gmail.com', 1),
+  ('fernanda.rodrigues.cdc@gmail.com', 9),
+  ('fernanda.rodrigues.cdc@gmail.com', 16);
 
 -- Update users rows and update user 4 with a location preference.
 -- As per PR feedback this will be implemented on a different schema.

--- a/database/schema-users-event.sql
+++ b/database/schema-users-event.sql
@@ -4,29 +4,29 @@ drop table if exists events_users cascade;
 create table events_users (
   id           bigserial not null primary key,
   events_id    bigserial not null,
-  user_id      bigserial not null
+  user_id      varchar(50) not null
 );
 
 -- Populate relationships
-insert into events_users (events_id, user_id) values (1, 2);
-insert into events_users (events_id, user_id) values (1, 4);
-insert into events_users (events_id, user_id) values (1, 6);
+insert into events_users (events_id, user_id) values (1, 'chiuycatherine@gmail.com');
+insert into events_users (events_id, user_id) values (1, 'fernanda.rodrigues.cdc@gmail.com');
+insert into events_users (events_id, user_id) values (1, 'yulanrong123@gmail.com');
 
-insert into events_users (events_id, user_id) values (2, 1);
-insert into events_users (events_id, user_id) values (2, 2);
-insert into events_users (events_id, user_id) values (2, 3);
+insert into events_users (events_id, user_id) values (2, 'alam1324@gmail.com');
+insert into events_users (events_id, user_id) values (2, 'chiuycatherine@gmail.com');
+insert into events_users (events_id, user_id) values (3, 'ericbaldwinn@gmail.com');
 
-insert into events_users (events_id, user_id) values (3, 3);
-insert into events_users (events_id, user_id) values (3, 2);
-insert into events_users (events_id, user_id) values (3, 4);
-insert into events_users (events_id, user_id) values (3, 1);
+insert into events_users (events_id, user_id) values (3, 'ericbaldwinn@gmail.com');
+insert into events_users (events_id, user_id) values (3, 'chiuycatherine@gmail.com');
+insert into events_users (events_id, user_id) values (3, 'fernanda.rodrigues.cdc@gmail.com');
+insert into events_users (events_id, user_id) values (3, 'alam1324@gmail.com');
 
-insert into events_users (events_id, user_id) values (6, 4);
-insert into events_users (events_id, user_id) values (6, 6);
+insert into events_users (events_id, user_id) values (6, 'fernanda.rodrigues.cdc@gmail.com');
+insert into events_users (events_id, user_id) values (6, 'yulanrong123@gmail.com');
 
-insert into events_users (events_id, user_id) values (5, 2);
-insert into events_users (events_id, user_id) values (5, 1);
-insert into events_users (events_id, user_id) values (5, 6);
+insert into events_users (events_id, user_id) values (5, 'chiuycatherine@gmail.com');
+insert into events_users (events_id, user_id) values (5, 'alam1324@gmail.com');
+insert into events_users (events_id, user_id) values (5, 'yulanrong123@gmail.com');
 
 
 alter table events_users add constraint events_id_fkey foreign key (events_id) references events(id);

--- a/database/schema-users.sql
+++ b/database/schema-users.sql
@@ -7,7 +7,7 @@ create table users (
   email                 varchar(50) not null,
   full_name             varchar(50) not null,
   has_completed_survey  boolean default false,
-  location_id           bigserial not null default 1
+  location_id           bigserial not null
 );
 
 -- Foreign key

--- a/database/schema-users.sql
+++ b/database/schema-users.sql
@@ -3,9 +3,9 @@ drop table if exists users cascade;
 
 -- Create tables
 create table users (
-  id                    bigserial not null primary key,
-  full_name             varchar(50) not null,
+  id                    varchar(50) not null primary key,
   email                 varchar(50) not null,
+  full_name             varchar(50) not null,
   has_completed_survey  boolean default false,
   location_id           bigserial not null
 );
@@ -14,12 +14,12 @@ create table users (
 alter table users add constraint user_location_fk foreign key (location_id) references locations(id);
 
 -- Populate users table
-insert into users (full_name, email, location_id) values ('Andrew Lam', 'andrew@test.com', 1);
-insert into users (full_name, email, location_id) values ('Catherine Chiu', 'cat@test.com', 2);
-insert into users (full_name, email, location_id) values ('Eric Baldwin', 'eric@test.com', 3);
-insert into users (full_name, email, location_id) values ('Fernanda Silva', 'nanda@test.com', 4);
-insert into users (full_name, email, location_id) values ('Sean Welch', 'sean@test.com', 2);
-insert into users (full_name, email, location_id) values ('Yulan Rong', 'yulan@test.com', 3);
+insert into users (id, email, full_name, location_id) values ('alam1324@gmail.com', 'alam1324@gmail.com', 'Andrew Lam', 1);
+insert into users (id, email, full_name, location_id) values ('chiuycatherine@gmail.com', 'chiuycatherine@gmail.com', 'Catherine Chiu', 2);
+insert into users (id, email, full_name, location_id) values ('ericbaldwinn@gmail.com', 'ericbaldwinn@gmail.com', 'Eric Baldwin', 3);
+insert into users (id, email, full_name, location_id) values ('fernanda.rodrigues.cdc@gmail.com', 'fernanda.rodrigues.cdc@gmail.com', 'Fernanda Silva', 4);
+insert into users (id, email, full_name, location_id) values ('sean.welch@me.com', 'sean.welch@me.com', 'Sean Welch', 2);
+insert into users (id, email, full_name, location_id) values ('yulanrong123@gmail.com', 'yulanrong123@gmail.com', 'Yulan Rong', 3);
 
 -- Update users rows and update user 4 with a location preference.
-update users set location_id = 1 where id = 4; -- Update user Fernanda with the location San Francisco
+update users set location_id = 1 where id = 'fernanda.rodrigues.cdc@gmail.com'; -- Update user Fernanda with the location San Francisco

--- a/database/schema-users.sql
+++ b/database/schema-users.sql
@@ -7,7 +7,7 @@ create table users (
   email                 varchar(50) not null,
   full_name             varchar(50) not null,
   has_completed_survey  boolean default false,
-  location_id           bigserial not null
+  location_id           bigserial not null default 1
 );
 
 -- Foreign key

--- a/server/models/events.js
+++ b/server/models/events.js
@@ -66,9 +66,9 @@ const addUserToEvent = (user_id, event_id) => {
   const query = `
     insert into events_users
     (events_id, user_id)
-    values (${event_id}, ${user_id})
+    values ($1, $2)
   `
-  return db.pool.query(query);
+  return db.pool.query(query, [event_id, user_id]);
 }
 
 const removeUserFromEvent = (user_id, event_id) => {

--- a/server/models/friends.js
+++ b/server/models/friends.js
@@ -15,6 +15,7 @@ const getFriends = (id) => {
       on u.location_id = l.id
     left join relationships r
       on u.id = r.from_user_id
+      and r.to_user_id = $1
     where u.id <> $1
     order by friend desc, u.id
   `;

--- a/server/models/preferences.js
+++ b/server/models/preferences.js
@@ -23,8 +23,8 @@ const getSurvey = () => {
 }
 
 const getUserPreferences = (userId) => {
-  const query = `SELECT json_agg(preferences_id) FROM  users_preferences where user_id = ${userId}`
-  return db.pool.query(query);
+  const query = 'SELECT json_agg(preferences_id) FROM  users_preferences where user_id = $1'
+  return db.pool.query(query, [userId]);
 }
 
 const getLabelOfPrefById = (id) => {
@@ -38,12 +38,12 @@ const getAllCategories = () => {
 }
 
 const removeUserPreferences = (userId) => {
-  const query = `DELETE from users_preferences WHERE user_id = ${userId}`;
-  return db.pool.query(query);
+  const query = 'DELETE from users_preferences WHERE user_id = $1';
+  return db.pool.query(query, [userId]);
 }
 
 const postUserPreferences = ({userId, preferences}) => {
-  const values = preferences.map(preferenceId => `(${userId} , ${preferenceId})`).join(',');
+  const values = preferences.map(preferenceId => `('${userId}' , ${preferenceId})`).join(',');
   const query = `insert into users_preferences (user_id, preferences_id) values ${values};`
 
   return db.pool.query(query);

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -1,8 +1,8 @@
 const db = require('../../database');
 
 const addUser = (id, email, full_name) => {
-  const query = `insert into users (email, full_name) values ($1, $2);`;
-  return db.pool.query(query, [email, full_name]);
+  const query = `insert into users (id, email, full_name) values ($1, $2, $3);`;
+  return db.pool.query(query, [id, email, full_name]);
 }
 
 const getUser = (id) => {


### PR DESCRIPTION
Changes:
- Update schemas and registration to use email (varchar) as id
- Update my events, friends, and interests to use the logged in user instead of a hardcoded user

Notes:
- After pulling in this PR, you will need to run `bash schema.sh` to recreate your schemas
- If you want to test using an existing Firebase account, insert the account into the `users` table

To do:
- The "Friend's Events" button was not passing the `friend_id` to the events list prior to this PR, so we still need to update that

Video: [https://i.imgur.com/xTZcXZK.mp4](https://i.imgur.com/xTZcXZK.mp4)